### PR TITLE
fix(repo_override): use common flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn add_link(path: &mut PathBuf, mut bazelrc: &mut File) -> std::io::Result<()> {
 
     writeln!(
         bazelrc,
-        "build --override_repository={}={}",
+        "common --override_repository={}={}",
         workspace_name,
         workspace_path.to_str().unwrap()
     )

--- a/src/repo_overrides.rs
+++ b/src/repo_overrides.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::io::prelude::*;
 
 #[derive(Debug, Deserialize, Recap)]
-#[recap(regex = r#"build --override_repository=(?P<workspace>\S+)=(?P<path>\S+)"#)]
+#[recap(regex = r#"common --override_repository=(?P<workspace>\S+)=(?P<path>\S+)"#)]
 pub struct OverrideRepository {
     pub workspace: String,
     pub path: String,


### PR DESCRIPTION
Use the `common` tag now that it's fixed upstream: https://blog.bazel.build/2020/03/03/bazel-2-2.html?utm_source=feedburner&utm_medium=email&utm_campaign=Feed%3A+BazelBlog+%28Bazel+Blog%29

This makes sure that no matter what bazel command you run it respects your overrides